### PR TITLE
Repaired broken label functionality for Firefox. Fixes #7

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -366,13 +366,13 @@ footer p {
   font-size: 1.0em;
 }
 
-label {
+.input-row {
   display: block;
   margin-top: 0.5em;
   font-size: 1.25em;
 }
 
-label > input[type=radio] {
+.input-row input[type=radio] {
   position:relative;
   top: -0.25em;
 }

--- a/templates/question_is_fixed.hbs
+++ b/templates/question_is_fixed.hbs
@@ -1,25 +1,25 @@
 <p>On Node 0.10?</p>
 <div class="question">
-  <label>
+  <label class="input-row">
     <input type="radio" name="answer_node_10" value="yes" checked> Yes
   </label>
-  <label>
+  <label class="input-row">
     <input type="radio" name="answer_node_10" value="no"> No
   </label>
-  <label>
+  <label class="input-row">
     <input type="radio" name="answer_node_10" value="unknown"> I can&#39;t tell.
   </label>
 </div>
 
 <p>On Node 0.11?</p>
 <div class="question">
-  <label>
+  <label class="input-row">
     <input type="radio" name="answer_node_11" value="yes" checked> Yes
   </label>
-  <label>
+  <label class="input-row">
     <input type="radio" name="answer_node_11" value="no"> No
   </label>
-  <label>
+  <label class="input-row">
     <input type="radio" name="answer_node_11" value="unknown"> I can&#39;t tell.
   </label>
 </div>

--- a/templates/question_list.hbs
+++ b/templates/question_list.hbs
@@ -1,14 +1,16 @@
 <div class="question">
-  <label class="question">
+  <label class="question input-row">
     <input type="radio" name="yesno" value="no">
     No, this issue is not a duplicate
   </label>
-  <label>
-    <input id="yes_value" type="radio" name="yesno" value="yes">
-    Yes, this issue duplicates
+  <div class="input-row">
+    <label>
+      <input id="yes_value" type="radio" name="yesno" value="yes">
+      Yes, this issue duplicates
+    </label>
     <input type="text" onfocusin="void(yes_value.checked=true);" name="issues" placeholder="#issueNumber, #issueNumber" />
-  </label>
-  <label class="question on_question_1">
+  </div>
+  <label class="question input-row on_question_1">
     <input type="radio" name="yesno" value="unknown" checked>
     I can&#39;t tell.
   </label>

--- a/templates/question_yesnomaybe.hbs
+++ b/templates/question_yesnomaybe.hbs
@@ -1,11 +1,11 @@
 <div class="question">
-  <label>
+  <label class="input-row">
     <input type="radio" name="answer" value="yes" checked> Yes
   </label>
-  <label>
+  <label class="input-row">
     <input type="radio" name="answer" value="no"> No
   </label>
-  <label>
+  <label class="input-row">
     <input type="radio" name="answer" value="unknown"> I can&#39;t tell.
   </label>
 </div>


### PR DESCRIPTION
As reported in #7, Firefox dislikes having 2 `inputs` in 1 `label`. In this PR:
- Relocated second `input` outside of `label` thus fixing behavior
- Renamed `label` CSS to `.input-row` to make it more reusable and less conflict prone
- Updated all containers for `input's` to use `.input-row` to preserve previous styling

This has not been tested with a live server. It has been tested with copy/paste/replace HTML/CSS in the browser. I attempted to get a `vagrant` box running but got frustrated with `postgres` setup.

https://github.com/twolfson/vagrant-nodebugme

On another note, I noticed a lot of bad practices in the CSS. Using content semantic classes can lead to unnecessary issues and extra work like having to update all `label's` to `.input-row's`. From my experience, using [OOCSS](http://oocss.org/) conventions leads to less issues and more reusable classes. If you would like an explanation of how OOCSS could apply to this project, let me know and I will elaborate in another thread.
