### PR TITLE
Moved from listening on localhost to `0.0.0.0` to allow port forwarding

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ function getServer(ready) {
   var server
 
   settings = getSettings(process.env.MODE)
-  server = hapi.createServer('localhost', settings.port, settings.server)
+  server = hapi.createServer('0.0.0.0', settings.port, settings.server)
 
   require('./lib/hbs-helpers/user-issue.js')(handlebars, settings)
   require('./lib/hbs-helpers/analytics.js')(handlebars, settings)


### PR DESCRIPTION
I have `Vagrant` running but ran into a snag regarding port forwarding. Since we are using `localhost` as the `hostname`, we are only allowing connections from the same computer. To fix this, I have moved to `0.0.0.0` which allows connections from anywhere.

https://github.com/hapijs/hapi/blob/master/docs/Reference.md#createserverhost-port-options

One option is to move this into `settings.host`.

In my past experience, it is good to create a `settings.url.internal` and `settings.url.external` (and maybe a `settings.url.static` for here). It allows for the distinction of where we should be listening locally (`internal`) and where to comment about absolute URLs (`external`) (e.g. when writing to `console`).

https://github.com/twolfson/site/compare/dev/external.url
